### PR TITLE
Update Usage of GTFO Command

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gtfo.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gtfo.java
@@ -16,7 +16,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @CommandPermissions(level = AdminLevel.SUPER, source = SourceType.BOTH, blockHostConsole = true)
-@CommandParameters(description = "Makes someone GTFO (deop and ip ban by username).", usage = "/<command> <partialname>")
+@CommandParameters(description = "Makes someone GTFO (deop and ip ban by username).", usage = "/<command> <partialname> [reason]")
 public class Command_gtfo extends TFM_Command
 {
     @Override


### PR DESCRIPTION
Here my PR, this may be a bit of a useless PR, but most new admins will not know that they can add a reason to their GTFO bans. Currently, there isn't a [reason] box to the GTFO command usage when you execute /gtfo on its own but you can provide a reason to it still.
